### PR TITLE
fix: correct last quarter moon phase label

### DIFF
--- a/pkg/astral/moon.go
+++ b/pkg/astral/moon.go
@@ -76,7 +76,7 @@ func MoonPhaseDescription(x float64) (string, error) {
 		return "Full Moon", nil
 	}
 	if x >= 21 && x < 28 {
-		return "Laster Quarter", nil
+		return "Last Quarter", nil
 	}
 
 	return "", fmt.Errorf("failed parsing %v", x)


### PR DESCRIPTION
Fixes #38

Replace the `Laster Quarter` typo in the moon phase output with `Last Quarter`.