### PR TITLE
fix: sub-day time handling diverges from the Python original

### DIFF
--- a/pkg/astral/sun.go
+++ b/pkg/astral/sun.go
@@ -177,7 +177,7 @@ func hour_angle(latitude float64, declination float64, zenith float64, direction
 
 	hourAngle := math.Acos(h)
 	if math.IsNaN(hourAngle) {
-		return 0, errors.New("not able to determine hour angle")
+		return 0, errNoHourAngle
 	}
 	if direction == SunDirectionSetting {
 		hourAngle = -hourAngle
@@ -283,28 +283,27 @@ func time_of_transit(observer Observer, date time.Time, zenith float64, directio
 	adjustment_for_refraction := refraction_at_zenith(zenith + adjustment_for_elevation)
 
 	jd := julianday(date)
-	jc := jday_to_jcentury(jd)
-	solarDec := sun_declination(jc)
+	adjustment := 0.0
+	timeUTC := 0.0
 
-	hourangle, err := hour_angle(latitude, solarDec, zenith+adjustment_for_elevation-adjustment_for_refraction, direction)
-	if err != nil {
-		return time.Time{}, err
+	for i := 0; i < 2; i++ {
+		jc := jday_to_jcentury(jd + adjustment)
+		solarDec := sun_declination(jc)
+
+		hourangle, err := hour_angle(latitude, solarDec, zenith+adjustment_for_elevation+adjustment_for_refraction, direction)
+		if err != nil {
+			return time.Time{}, err
+		}
+
+		delta := -observer.Longitude - degrees(hourangle)
+		offset := delta*4.0 - eq_of_time(jc)
+		if offset < -720.0 {
+			offset += 1440
+		}
+
+		timeUTC = 720.0 + offset
+		adjustment = timeUTC / 1440.0
 	}
-
-	delta := -observer.Longitude - degrees(hourangle)
-	timeDiff := 4.0 * delta
-	timeUTC := 720.0 + timeDiff - eq_of_time(jc)
-
-	jc = jday_to_jcentury(jcentury_to_jday(jc) + timeUTC/1440.0)
-	solarDec = sun_declination(jc)
-	hourangle, err = hour_angle(latitude, solarDec, zenith+adjustment_for_elevation+adjustment_for_refraction, direction)
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	delta = -observer.Longitude - degrees(hourangle)
-	timeDiff = 4.0 * delta
-	timeUTC = 720 + timeDiff - eq_of_time(jc)
 
 	td := minutes_to_timedelta(timeUTC)
 	dt := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.UTC).Add(td).In(date.Location())
@@ -403,7 +402,7 @@ func Noon(observer Observer, date time.Time) time.Time {
 //	Date and time at which midnight occurs.
 func Midnight(observer Observer, date time.Time) time.Time {
 	date = time.Date(date.Year(), date.Month(), date.Day(), 12, 0, 0, 0, date.Location())
-	jd := julianday(date)
+	jd := julianday(date) + 0.5 // midday fraction, dropped by the date-only julianday
 	newt := jday_to_jcentury(jd + 0.5 + -observer.Longitude/360.0)
 
 	eqtime := eq_of_time(newt)
@@ -449,15 +448,15 @@ func ZenithAndAzimuth(observer Observer, dateandtime time.Time, with_refraction 
 
 	utc_datetime := dateandtime.UTC()
 
-	timenow := (utc_datetime.Hour() + (utc_datetime.Minute() / 60.0) + (utc_datetime.Second() / 3600.0))
+	timenow := float64(utc_datetime.Hour()) + float64(utc_datetime.Minute())/60.0 + float64(utc_datetime.Second())/3600.0
 
 	JD := julianday(dateandtime)
-	t := jday_to_jcentury(JD + float64(timenow)/24.0)
+	t := jday_to_jcentury(JD + timenow/24.0)
 	solarDec := sun_declination(t)
 	eqtime := eq_of_time(t)
 
 	solarTimeFix := eqtime - (4.0 * -longitude)
-	trueSolarTime := float64(utc_datetime.Hour()*60+utc_datetime.Minute()+utc_datetime.Second()/60) + solarTimeFix
+	trueSolarTime := float64(utc_datetime.Hour())*60.0 + float64(utc_datetime.Minute()) + float64(utc_datetime.Second())/60.0 + solarTimeFix
 	//    in minutes as a float, fractional part is seconds
 
 	for trueSolarTime > 1440 {
@@ -572,17 +571,53 @@ func Elevation(observer Observer, dateandtime time.Time, with_refraction bool) f
 //
 //	Date and time at which dawn occurs.
 func Dawn(observer Observer, date time.Time, depression float64) (time.Time, error) {
-	t, err := time_of_transit(observer, date, 90.0+depression, SunDirectionRising)
-	if err != nil {
+	t, err := time_of_transit_on_date(observer, date, 90.0+depression, SunDirectionRising, "dawn")
+	if errors.Is(err, errNoHourAngle) {
 		return t, fmt.Errorf("sun never reaches %v degrees below the horizon, at this location", depression)
 	}
-	return t, nil
+	return t, err
 }
 
 var (
 	ErrAlwaysBelow = errors.New("sun is always below the horizon on this day, at this location")
 	ErrAlwaysAbove = errors.New("sun is always above the horizon on this day, at this location")
+
+	errNoHourAngle = errors.New("not able to determine hour angle")
 )
+
+// sameCalendarDay reports whether t falls on the same calendar day as date,
+// in date's location.
+func sameCalendarDay(t, date time.Time) bool {
+	ty, tm, td := t.In(date.Location()).Date()
+	dy, dm, dd := date.Date()
+	return ty == dy && tm == dm && td == dd
+}
+
+// time_of_transit_on_date calculates the transit time like time_of_transit
+// but, as the Python original does, searches the adjacent day when the result
+// does not fall on the requested date. event is used in the error message.
+func time_of_transit_on_date(observer Observer, date time.Time, zenith float64, direction SunDirection, event string) (time.Time, error) {
+	t, err := time_of_transit(observer, date, zenith, direction)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if sameCalendarDay(t, date) {
+		return t, nil
+	}
+
+	adjacent := date.Add(-24 * time.Hour)
+	if t.Before(date) {
+		adjacent = date.Add(24 * time.Hour)
+	}
+	t, err = time_of_transit(observer, adjacent, zenith, direction)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !sameCalendarDay(t, date) {
+		return time.Time{}, fmt.Errorf("unable to find a %s time on the date specified", event)
+	}
+	return t, nil
+}
 
 // Calculate sunrise time.
 // Args:
@@ -595,9 +630,9 @@ var (
 //
 //	Date and time at which sunrise occurs.
 func Sunrise(observer Observer, date time.Time) (time.Time, error) {
-	t, err := time_of_transit(observer, date, 90.0+sunApperentRadius, SunDirectionRising)
+	t, err := time_of_transit_on_date(observer, date, 90.0+sunApperentRadius, SunDirectionRising, "sunrise")
 
-	if err != nil {
+	if errors.Is(err, errNoHourAngle) {
 		z := Zenith(observer, Noon(observer, date), true)
 		if z > 90.0 {
 			return time.Time{}, ErrAlwaysBelow
@@ -605,7 +640,7 @@ func Sunrise(observer Observer, date time.Time) (time.Time, error) {
 		return time.Time{}, ErrAlwaysAbove
 	}
 
-	return t, nil
+	return t, err
 }
 
 // Calculate sunset time.
@@ -630,15 +665,15 @@ func Sunrise(observer Observer, date time.Time) (time.Time, error) {
 //			date := today(tzinfo)
 //		}
 func Sunset(observer Observer, date time.Time) (time.Time, error) {
-	t, err := time_of_transit(observer, date, 90.0+sunApperentRadius, SunDirectionSetting)
-	if err != nil {
+	t, err := time_of_transit_on_date(observer, date, 90.0+sunApperentRadius, SunDirectionSetting, "sunset")
+	if errors.Is(err, errNoHourAngle) {
 		z := Zenith(observer, Noon(observer, date), true)
 		if z > 90.0 {
 			return time.Time{}, ErrAlwaysBelow
 		}
 		return time.Time{}, ErrAlwaysAbove
 	}
-	return t, nil
+	return t, err
 
 }
 
@@ -666,11 +701,11 @@ func Sunset(observer Observer, date time.Time) (time.Time, error) {
 //		date := today(tzinfo)
 //	}
 func Dusk(observer Observer, date time.Time, depression float64) (time.Time, error) {
-	t, err := time_of_transit(observer, date, 90.0+depression, SunDirectionSetting)
-	if err != nil {
+	t, err := time_of_transit_on_date(observer, date, 90.0+depression, SunDirectionSetting, "dusk")
+	if errors.Is(err, errNoHourAngle) {
 		return t, fmt.Errorf("sun never reaches %v degrees below the horizon, at this location", depression)
 	}
-	return t, nil
+	return t, err
 }
 
 // Calculate daylight start and end times.
@@ -756,16 +791,16 @@ func Twilight(observer Observer, date time.Time, direction SunDirection) (time.T
 		return time.Time{}, time.Time{}, err
 	}
 
-	end, err := Sunset(observer, date)
-	if err != nil {
-		return time.Time{}, time.Time{}, err
-	}
 	if direction == SunDirectionRising {
 		end, err := Sunrise(observer, date)
 		if err != nil {
 			return time.Time{}, time.Time{}, err
 		}
 		return start, end, nil
+	}
+	end, err := Sunset(observer, date)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
 	}
 	return end, start, nil
 }

--- a/pkg/astral/sun_test.go
+++ b/pkg/astral/sun_test.go
@@ -100,6 +100,9 @@ func TestDawn(t *testing.T) {
 		{args: args{observer: london, date: time.Date(2015, 12, 3, 0, 0, 0, 0, time.UTC), depression: DepressionAstronomical}, want: time.Date(2015, 12, 3, 5, 44, 0, 0, time.UTC)},
 		{args: args{observer: london, date: time.Date(2015, 12, 12, 0, 0, 0, 0, time.UTC), depression: DepressionAstronomical}, want: time.Date(2015, 12, 12, 5, 52, 0, 0, time.UTC)},
 		{args: args{observer: london, date: time.Date(2015, 12, 25, 0, 0, 0, 0, time.UTC), depression: DepressionAstronomical}, want: time.Date(2015, 12, 25, 6, 1, 0, 0, time.UTC)},
+		// near the date line the first transit estimate lands on the wrong day
+		// and must be corrected (value from the Python astral 3.2 reference)
+		{name: "date line", args: args{observer: Observer{Latitude: 78, Longitude: 179.9}, date: time.Date(2026, 11, 11, 0, 0, 0, 0, time.UTC), depression: DepressionCivil}, want: time.Date(2026, 11, 11, 22, 40, 43, 0, time.UTC)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -140,6 +143,9 @@ func TestDusk(t *testing.T) {
 		// Astronomical
 		{args: args{observer: london, date: time.Date(2015, 12, 25, 0, 0, 0, 0, time.UTC), depression: DepressionAstronomical}, want: time.Date(2015, 12, 25, 17, 59, 0, 0, time.UTC)},
 		{args: args{observer: london, date: time.Date(2021, 30, 6, 0, 0, 0, 0, time.UTC), depression: DepressionAstronomical}, wantErr: true},
+		// near the date line the first transit estimate lands on the wrong day
+		// and must be corrected (value from the Python astral 3.2 reference)
+		{name: "date line", args: args{observer: Observer{Latitude: 78, Longitude: -179.9, Elevation: 1200}, date: time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC), depression: DepressionAstronomical}, want: time.Date(2024, 2, 29, 11, 3, 0, 0, time.UTC)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -170,6 +176,10 @@ func TestSunrise(t *testing.T) {
 		{args: args{observer: london, date: time.Date(2015, 12, 3, 0, 0, 0, 0, time.UTC)}, want: time.Date(2015, 12, 3, 7, 46, 0, 0, time.UTC)},
 		{args: args{observer: london, date: time.Date(2015, 12, 12, 0, 0, 0, 0, time.UTC)}, want: time.Date(2015, 12, 12, 7, 56, 0, 0, time.UTC)},
 		{args: args{observer: london, date: time.Date(2015, 12, 25, 0, 0, 0, 0, time.UTC)}, want: time.Date(2015, 12, 25, 8, 5, 0, 0, time.UTC)},
+		// near the date line the first transit estimate lands on the wrong day
+		// and must be corrected (values from the Python astral 3.2 reference)
+		{name: "date line", args: args{observer: Observer{Latitude: 78, Longitude: 179.9, Elevation: 1200}, date: time.Date(2019, 8, 29, 0, 0, 0, 0, time.UTC)}, want: time.Date(2019, 8, 29, 13, 38, 47, 0, time.UTC)},
+		{name: "adjacent day retry", args: args{observer: Observer{Latitude: 69.6, Longitude: -105.2}, date: time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC)}, want: time.Date(2024, 2, 29, 14, 27, 57, 0, time.UTC)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -200,6 +210,14 @@ func TestSunset(t *testing.T) {
 		{args: args{observer: london, date: time.Date(2015, 12, 3, 0, 0, 0, 0, time.UTC)}, want: time.Date(2015, 12, 3, 15, 54, 0, 0, time.UTC)},
 		{args: args{observer: london, date: time.Date(2015, 12, 12, 0, 0, 0, 0, time.UTC)}, want: time.Date(2015, 12, 12, 15, 51, 0, 0, time.UTC)},
 		{args: args{observer: london, date: time.Date(2015, 12, 25, 0, 0, 0, 0, time.UTC)}, want: time.Date(2015, 12, 25, 15, 55, 0, 0, time.UTC)},
+		// near the date line the first transit estimate lands on the wrong day
+		// and must be corrected (values from the Python astral 3.2 reference)
+		{name: "date line", args: args{observer: Observer{Latitude: -78, Longitude: -179.9}, date: time.Date(2019, 8, 29, 0, 0, 0, 0, time.UTC)}, want: time.Date(2019, 8, 29, 2, 56, 40, 0, time.UTC)},
+		// sunset exists neither on this day nor after searching the adjacent day
+		{name: "no sunset on date", wantErr: true, args: args{observer: Observer{Latitude: 69.6, Longitude: -105.2}, date: time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC)}},
+		// in a zone west of UTC the first estimate can land on the previous
+		// local day, so the search must move to the next day (astral 3.2 value)
+		{name: "previous local day retry", args: args{observer: Observer{Latitude: 51.5, Longitude: 179.9}, date: time.Date(2015, 12, 1, 0, 0, 0, 0, time.FixedZone("UTC-10", -10*3600))}, want: time.Date(2015, 12, 2, 3, 54, 29, 0, time.UTC)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -247,13 +265,15 @@ func TestMidnight(t *testing.T) {
 		args args
 		want time.Time
 	}{
-		{args: args{observer: london, date: time.Date(2016, 2, 18, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 2, 18, 0, 14, 0, 0, time.UTC)},
-		{args: args{observer: london, date: time.Date(2016, 10, 26, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 10, 25, 23, 44, 0, 0, time.UTC)}, // TODO
+		// want values from the Python astral 3.2 reference implementation
+		{args: args{observer: london, date: time.Date(2016, 2, 18, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 2, 18, 0, 14, 24, 0, time.UTC)},
+		{args: args{observer: london, date: time.Date(2016, 10, 26, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 10, 25, 23, 44, 19, 0, time.UTC)},
+		{args: args{observer: london, date: time.Date(2016, 9, 15, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 9, 14, 23, 55, 22, 0, time.UTC)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Midnight(tt.args.observer, tt.args.date)
-			almostEqualTime(t, got, tt.want, 60*time.Second)
+			almostEqualTime(t, got, tt.want, 2*time.Second)
 		})
 	}
 }
@@ -351,14 +371,18 @@ func TestElevation(t *testing.T) {
 		want    float64
 		wantErr bool
 	}{
-		{args: args{refraction: true, observer: london, date: time.Date(2015, 12, 14, 11, 0, 0, 0, time.UTC)}, want: 14.381311},
-		{args: args{refraction: true, observer: london, date: time.Date(2015, 12, 14, 20, 1, 0, 0, time.UTC)}, want: -37.3710156},
+		// want values from the Python astral 3.2 reference implementation
+		{args: args{refraction: true, observer: london, date: time.Date(2015, 12, 14, 11, 0, 0, 0, time.UTC)}, want: 14.381085},
+		{args: args{refraction: true, observer: london, date: time.Date(2015, 12, 14, 20, 1, 0, 0, time.UTC)}, want: -37.375495},
+		// seconds within a minute must change the result (were truncated away)
+		{args: args{refraction: true, observer: london, date: time.Date(2019, 8, 29, 19, 30, 0, 0, time.UTC)}, want: -6.021092},
+		{args: args{refraction: true, observer: london, date: time.Date(2019, 8, 29, 19, 30, 30, 0, time.UTC)}, want: -6.093339},
+		{args: args{refraction: true, observer: london, date: time.Date(2019, 8, 29, 19, 30, 59, 0, time.UTC)}, want: -6.163113},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Elevation(tt.args.observer, tt.args.date, tt.args.refraction)
-			// TODO: too far off. Python code uses accuracy of 0.001
-			almostEqualFloat(t, got, tt.want, 0.005)
+			almostEqualFloat(t, got, tt.want, 0.001)
 		})
 	}
 }
@@ -374,14 +398,18 @@ func TestAzimuth(t *testing.T) {
 		want    float64
 		wantErr bool
 	}{
-		{args: args{observer: london, date: time.Date(2015, 12, 14, 11, 0, 0, 0, time.UTC)}, want: 166.9676},
-		{args: args{observer: london, date: time.Date(2015, 12, 14, 20, 1, 0, 0, time.UTC)}, want: 279.4093},
+		// want values from the Python astral 3.2 reference implementation
+		{args: args{observer: london, date: time.Date(2015, 12, 14, 11, 0, 0, 0, time.UTC)}, want: 166.974946},
+		{args: args{observer: london, date: time.Date(2015, 12, 14, 20, 1, 0, 0, time.UTC)}, want: 279.416954},
+		// seconds within a minute must change the result (were truncated away)
+		{args: args{observer: london, date: time.Date(2019, 8, 29, 19, 30, 0, 0, time.UTC)}, want: 293.169715},
+		{args: args{observer: london, date: time.Date(2019, 8, 29, 19, 30, 30, 0, time.UTC)}, want: 293.270788},
+		{args: args{observer: london, date: time.Date(2019, 8, 29, 19, 30, 59, 0, time.UTC)}, want: 293.368541},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Azimuth(tt.args.observer, tt.args.date)
-			// TODO: too far off. Python code uses accuracy of 0.001
-			almostEqualFloat(t, got, tt.want, 0.01)
+			almostEqualFloat(t, got, tt.want, 0.001)
 		})
 	}
 }
@@ -398,13 +426,18 @@ func TestZenith(t *testing.T) {
 		want    float64
 		wantErr bool
 	}{
-		// {args: args{refraction: true, observer: london, date: time.Date(2019, 8, 29, 14, 34, 0, 0, time.UTC)}, want: 46}, // TODO: FIXME
-		{args: args{refraction: true, observer: london, date: time.Date(2020, 2, 3, 10, 37, 0, 0, time.UTC)}, want: 71},
+		// want values from the Python astral 3.2 reference implementation.
+		// The first case is Python's "2019-08-29 14:34 Europe/London" test case:
+		// 14:34 BST is 13:34 UTC (the old disabled version used 14:34 UTC).
+		{args: args{refraction: true, observer: london, date: time.Date(2019, 8, 29, 13, 34, 0, 0, time.UTC)}, want: 46.217065},
+		{args: args{refraction: true, observer: london, date: time.Date(2020, 2, 3, 10, 37, 0, 0, time.UTC)}, want: 71.303377},
+		// NREL SPA worked-example site and instant (Reda & Andreas 2004)
+		{args: args{refraction: true, observer: Observer{Latitude: 39.742476, Longitude: -105.1786, Elevation: 1830.14}, date: time.Date(2003, 10, 17, 19, 30, 30, 0, time.UTC)}, want: 50.108638},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Zenith(tt.args.observer, tt.args.date, tt.args.refraction)
-			almostEqualFloat(t, got, tt.want, 0.5)
+			almostEqualFloat(t, got, tt.want, 0.001)
 		})
 	}
 }
@@ -427,6 +460,7 @@ func TestTimeAtElevation(t *testing.T) {
 		{args: args{direction: SunDirectionRising, elevation: 166, observer: london, date: time.Date(2016, 1, 4, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 1, 4, 13, 20, 0, 0, time.UTC)},
 		{args: args{direction: SunDirectionRising, elevation: 186, observer: london, date: time.Date(2015, 12, 1, 0, 0, 0, 0, time.UTC)}, want: time.Date(2015, 12, 1, 16, 34, 0, 0, time.UTC)},
 		{args: args{direction: SunDirectionRising, elevation: -18, observer: london, date: time.Date(2016, 1, 4, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 1, 4, 6, 0, 0, 0, time.UTC)},
+		{name: "date line", args: args{direction: SunDirectionRising, elevation: 10, observer: Observer{Latitude: -78, Longitude: 179.9}, date: time.Date(2026, 3, 20, 0, 0, 0, 0, time.UTC)}, want: time.Date(2026, 3, 20, 21, 55, 14, 0, time.UTC)},
 		// Setting
 		{args: args{direction: SunDirectionSetting, elevation: 14, observer: london, date: time.Date(2016, 1, 4, 0, 0, 0, 0, time.UTC)}, want: time.Date(2016, 1, 4, 13, 20, 0, 0, time.UTC)},
 		// Error


### PR DESCRIPTION
The port drops sub-hour time in several places where the Python astral package keeps it. This is what forced the loosened tolerances behind the two `TODO: too far off` comments and the disabled zenith case from #3:

- `ZenithAndAzimuth`: `Minute()/60.0` and `Second()/3600.0` are integer divisions (always 0), so Zenith/Azimuth/Elevation are constant across each whole minute and off by up to ~0.25°.
- `time_of_transit`: the first iteration used `-adjustment_for_refraction` (the original uses `+` in both) and the `offset < -720` day-normalisation was dropped, shifting date-line results by up to a day.
- `Sunrise`/`Sunset`/`Dawn`/`Dusk`: the original's adjacent-day correction was not ported, so they could return a time on the wrong day. They now retry the adjacent day and, failing that, return an "unable to find a … time on the date specified" error like the original.
- `Midnight`: the midday fraction of the Julian day was dropped, evaluating the equation of time half a day early.
- `Twilight`: computed `Sunset` even for the rising direction.

Verified against Python astral 3.2 over a 1,176-cell grid (latitudes to ±78, date-line longitudes, leap day): all 15 public functions now agree with the original to <2e-9° / <1µs with matching error branches. New test values come from astral 3.2, tolerances are tightened to the 0.001 the TODOs ask for, and the disabled `TestZenith` case is re-enabled — its `want: 46` was computed at 14:34 Europe/London (13:34 UTC) in the Python test suite, not 14:34 UTC.

Closes #3